### PR TITLE
Feature/pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: black
         exclude: (migrations)
         language_version: python3.11
-        args: [--line-length=79]
+        args: [--line-length=79, --skip-string-normalization]
 
 - repo: https://github.com/pycqa/flake8
   rev: 6.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     - id: mixed-line-ending
       args: [--fix=crlf]
     - id: no-commit-to-branch
-      args: [--branch, develop]
+      args: [--branch, main, --branch, develop]
 
 - repo: https://github.com/pycqa/isort
   rev: 5.12.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: check-added-large-files
+    - id: trailing-whitespace
+      args: [--markdown-linebreak-ext=md]
+    - id: check-merge-conflict
+    - id: mixed-line-ending
+      args: [--fix=crlf]
+    - id: no-commit-to-branch
+      args: [--branch, develop]
+
+- repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+  hooks:
+    - id: isort
+      args: [--settings, setup.cfg]
+
+- repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.7.0
+    hooks:
+      - id: black
+        exclude: (migrations)
+        language_version: python3.11
+        args: [--line-length=79]
+
+- repo: https://github.com/pycqa/flake8
+  rev: 6.1.0
+  hooks:
+    - id: flake8
+      additional_dependencies:
+        - flake8-docstrings
+      args: [--config, setup.cfg]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,12 @@ repos:
       args: [--settings, setup.cfg]
 
 - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.7.0
-    hooks:
-      - id: black
-        exclude: (migrations)
-        language_version: python3.11
-        args: [--line-length=79, --skip-string-normalization]
+  rev: 23.7.0
+  hooks:
+    - id: black
+      exclude: (migrations)
+      language_version: python3.11
+      args: [--line-length=79, --skip-string-normalization]
 
 - repo: https://github.com/pycqa/flake8
   rev: 6.1.0

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Бекэнд
+
+## Использование pre-commit hooks
+- Установите все необходимые зависимости
+```
+pip install -r requirements.txt
+```
+- Установите pre-commit
+```
+pre-commit install
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,16 @@
 asgiref==3.7.2
+cfgv==3.4.0
+distlib==0.3.7
 Django==4.2.4
 django-filter==23.2
 djangorestframework==3.14.0
+filelock==3.12.2
+identify==2.5.26
+nodeenv==1.8.0
+platformdirs==3.10.0
+pre-commit==3.3.3
 pytz==2023.3
+PyYAML==6.0.1
 sqlparse==0.4.4
 tzdata==2023.3
+virtualenv==20.24.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,32 @@
+[flake8]
+ignore =
+    W503,
+    D100,
+    D101,
+    D102,
+    D103,
+    D104,
+    D105,
+    D106,
+    D107
+exclude =
+    .env,
+    .env.example,
+    .git,
+    __pycache__,
+    venv/,
+    env/,
+    */tests/*,
+    */migrations/*
+max-line-length = 79
+max-complexity = 10
+classmethod-decorators =
+    classmethod,
+    validator,
+    root_validator
+
+[isort]
+skip =
+    tests/,
+    migrations/
+profile = black


### PR DESCRIPTION
Добавлен pre-commit hooks, который позволит избежать некоторых проблем.

1. check-yaml, проверяет .yaml файлы на корректность
2.  end-of-file-fixer - проверяет, чтобы файл был либо пустым либо имел пустую строку в конце
3. check-added-large-files - не дает запушить файлы больше 500кБ
4. trailing-whitespace - удаляет лишние пробелы в конце строк
5. check-merge-conflict - проверяет файлы на наличие конфликтов слияния
6. mixed-line-ending - насильно меняет символы конца строки на CRLF, помогает избежать лишних проблем при разрешении конфликтов слияния
7. no-commit-to-branch - запрещает делать коммиты напрямую в ветку develop (только через PR)
8. isort - сортирует импорты
9. flake8 - линтер
10. black - форматтер кода, преобразует весь код под единый стиль