### PR TITLE
Добавлен редирект для роутов с '/api/' чтобы их обрабатывал django

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -15,6 +15,14 @@ server {
         proxy_pass http://backend:8000/admin/;
     }
 
+    location /api/ {
+        proxy_pass http://backend:8000/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
         root /usr/share/nginx/html;
         index  index.html index.htm;


### PR DESCRIPTION
Должны пропасть редиректы /api/ на 127.0.0.1